### PR TITLE
Feature/rake console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - "2.0.0"
+  - "2.1.0"
+gemfile: Gemfile
+script: "bundle exec rake test"
+notifications:
+  hipchat:
+    secure: "gudRADJSee2dN9r3/Ub1KNXxiUm9mhU7FdtD0QBUc6EF+MsJT4iZdXnpzqU0iDhTdvKY8I1Yp/mDwdbK15pvKaYaY0IcT+2U689F5GlKK5PhelE187Yd4WwCvGL3Nxds/J+F+r0o/MHUeLZhyU655uMKwtbDlrQF9ZZZ+nn6LuI="

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Bailiff
 
+[![Code Climate](https://codeclimate.com/github/bailiff/bailiff.png)](https://codeclimate.com/github/bailiff/bailiff)
+[![Build Status](https://travis-ci.org/bailiff/bailiff.png?branch=feature/code_quality_assurance)](https://travis-ci.org/bailiff/bailiff)
+
 TODO: Write a gem description
 
 ## Installation

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,10 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.pattern = 'test/*_test.rb'
 end
+
+task :console do
+  require 'pry'
+  require 'bailiff'
+  ARGV.clear
+  Pry.start
+end

--- a/bailiff.gemspec
+++ b/bailiff.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'minitest', '~> 4.7'
+  spec.add_development_dependency 'pry'
 end

--- a/bailiff.gemspec
+++ b/bailiff.gemspec
@@ -13,12 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://www.openminds.be'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split('\x0')
+  spec.files         = Dir['README.md', 'LICENSE', 'lib/*', 'lib/**/*']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'net-ssh', '~> 2.7'
+
   spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'rake', '~> 10.1'
+  spec.add_development_dependency 'minitest', '~> 4.7'
 end


### PR DESCRIPTION
Automatically adds './lib' to the load path and loads the gem with pry when you type in 'rake console'.

See: http://erniemiller.org/2014/02/05/7-lines-every-gems-rakefile-should-have/?utm_source=rubyweekly&utm_medium=email
